### PR TITLE
fix CRUD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,10 +198,12 @@ mod test {
     async fn should_find_todo() {
         let expected = TodoEntity::new(1, "should_find_todo".to_string());
 
+        todo!("labelデータの追加");
+        let labels = vec![];
         let todo_repository = TodoRepositoryForMemory::new();
         let label_repository = LabelRepositoryForMemory::new();
         todo_repository
-            .create(CreateTodo::new("should_find_todo".to_string()))
+            .create(CreateTodo::new("should_find_todo".to_string(), labels))
             .await
             .expect("failed create todo");
         let label_repository = LabelRepositoryForMemory::new();
@@ -218,10 +220,12 @@ mod test {
     async fn should_get_all_todos() {
         let expected = TodoEntity::new(1, "should_get_all_todos".to_string());
 
+        todo!("labelデータの追加");
+        let labels = vec![];
         let todo_repository = TodoRepositoryForMemory::new();
         let label_repository = LabelRepositoryForMemory::new();
         todo_repository
-            .create(CreateTodo::new("should_get_all_todos".to_string()))
+            .create(CreateTodo::new("should_get_all_todos".to_string(), labels))
             .await
             .expect("failed create todo");
         let req = build_todo_req_with_empty(Method::GET, "/todos");
@@ -262,10 +266,12 @@ mod test {
     async fn should_update_todo() {
         let expected = TodoEntity::new(1, "should_update_todo".to_string());
 
+        todo!("labelデータの追加");
+        let labels = vec![];
         let todo_repository = TodoRepositoryForMemory::new();
         let label_repository = LabelRepositoryForMemory::new();
         todo_repository
-            .create(CreateTodo::new("before_update_todo".to_string()))
+            .create(CreateTodo::new("before_update_todo".to_string(), labels))
             .await
             .expect("failed create todo");
         let req = build_todo_req_with_json(
@@ -288,10 +294,12 @@ mod test {
 
     #[tokio::test]
     async fn should_delete_todo() {
+        todo!("labelデータの追加");
+        let labels = vec![];
         let todo_repository = TodoRepositoryForMemory::new();
         let label_repository = LabelRepositoryForMemory::new();
         todo_repository
-            .create(CreateTodo::new("should_delete_todo".to_string()))
+            .create(CreateTodo::new("should_delete_todo".to_string(), labels))
             .await
             .expect("failed create todo");
         let req = build_todo_req_with_empty(Method::DELETE, "/todos/1");

--- a/src/repositories/todo.rs
+++ b/src/repositories/todo.rs
@@ -31,6 +31,13 @@ pub struct TodoEntity {
     pub labels: Vec<Label>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, FromRow)]
+struct TodoFromRow {
+    id: i32,
+    text: String,
+    completed: bool,
+}
+
 fn fold_entities(rows: Vec<TodoWithLabelFromRow>) -> Vec<TodoEntity> {
     let mut rows = rows.iter();
     let mut accum: Vec<TodoEntity> = vec![];
@@ -67,13 +74,6 @@ fn fold_entities(rows: Vec<TodoWithLabelFromRow>) -> Vec<TodoEntity> {
     accum
 }
 
-fn fold_entity(row: TodoWithLabelFromRow) -> TodoEntity {
-    let todo_entities = fold_entities(vec![row]);
-    let todo = todo_entities.first().expect("expect 1 todo");
-
-    todo.clone()
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Validate)]
 pub struct CreateTodo {
     #[validate(length(
@@ -82,6 +82,7 @@ pub struct CreateTodo {
         message = "At least 1 character and less than 100 characters."
     ))]
     text: String,
+    labels: Vec<i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Validate)]
@@ -93,6 +94,7 @@ pub struct UpdateTodo {
     ))]
     text: Option<String>,
     completed: Option<bool>,
+    labels: Option<Vec<i32>>,
 }
 
 #[derive(Debug, Clone)]
@@ -109,7 +111,8 @@ impl TodoRepositoryForDb {
 #[async_trait]
 impl TodoRepository for TodoRepositoryForDb {
     async fn create(&self, payload: CreateTodo) -> anyhow::Result<TodoEntity> {
-        let todo = sqlx::query_as::<_, TodoWithLabelFromRow>(
+        let tx = self.pool.begin().await?;
+        let row = sqlx::query_as::<_, TodoFromRow>(
             r#"
             insert into todos (text, completed)
             values ($1, false)
@@ -120,42 +123,66 @@ impl TodoRepository for TodoRepositoryForDb {
         .fetch_one(&self.pool) // query_asに渡した型のgenerics型を返す(Todo)
         .await?;
 
-        Ok(fold_entity(todo))
+        sqlx::query(
+            r#"
+            insert into todo_labels (todo_id, label_id)
+            select $1, id
+            from unnest($2) as t(id);
+            "#,
+        )
+        .bind(row.id)
+        .bind(payload.labels)
+        .execute(&self.pool)
+        .await?;
+
+        tx.commit().await?;
+
+        let todo = self.find(row.id).await?;
+        Ok(todo)
     }
 
     async fn find(&self, id: i32) -> anyhow::Result<TodoEntity> {
-        let todo = sqlx::query_as::<_, TodoWithLabelFromRow>(
+        let items = sqlx::query_as::<_, TodoWithLabelFromRow>(
             r#"
-            select * from todos where id=$1
+            select todos.*, labels.id as label_id, labels.name as label_name from todos
+            left outer join todo_labels t1 on todo.id = t1.todo_id
+            left outer join labels on labels.id = t1.label_id where todos.id=$1;
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_all(&self.pool)
         .await
         .map_err(|e| match e {
             sqlx::Error::RowNotFound => RepositoryError::NotFound(id),
             _ => RepositoryError::Unexpected(e.to_string()),
         })?;
 
-        Ok(fold_entity(todo))
+        let todos = fold_entities(items);
+        let todo = todos.first().ok_or(RepositoryError::NotFound(id))?;
+
+        Ok(todo.clone())
     }
 
     async fn all(&self) -> anyhow::Result<Vec<TodoEntity>> {
-        let todos = sqlx::query_as::<_, TodoWithLabelFromRow>(
+        let items = sqlx::query_as::<_, TodoWithLabelFromRow>(
             r#"
-            select * from todos
-            order by id desc;
+            select todos.*, labels.id as label_id, labels.name as label_name from todos
+            left outer join todo_labels t1 on todos.id = t1.todo_id
+            left outer join labels on labels.id = t1.label_id order by todos.id desc;
             "#,
         )
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(fold_entities(todos))
+        Ok(fold_entities(items))
     }
 
     async fn update(&self, id: i32, payload: UpdateTodo) -> anyhow::Result<TodoEntity> {
+        let tx = self.pool.begin().await?;
+
+        // todo update
         let old_todo = self.find(id).await?;
-        let todo = sqlx::query_as::<_, TodoWithLabelFromRow>(
+        sqlx::query(
             r#"
             update todos set text=$1, completed=$2
             where id=$3
@@ -168,22 +195,67 @@ impl TodoRepository for TodoRepositoryForDb {
         .fetch_one(&self.pool)
         .await?;
 
-        Ok(fold_entity(todo))
+        if let Some(labels) = payload.labels {
+            // todo's label update
+            // 一度関連するレコードを削除
+            sqlx::query(
+                r#"
+                delete from todo_labels where todo_id=$1
+                "#,
+            )
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+            sqlx::query(
+                r#"
+                insert into todo_labels (todo_id, label_id)
+                select $1, id
+                from unnest($2) as t(id)
+                "#,
+            )
+            .bind(id)
+            .bind(labels)
+            .execute(&self.pool)
+            .await?;
+        };
+
+        tx.commit().await?;
+        let todo = self.find(id).await?;
+
+        Ok(todo)
     }
 
     async fn delete(&self, id: i32) -> anyhow::Result<()> {
+        let tx = self.pool.begin().await?;
+        // todo's label delete
+        sqlx::query(
+            r#"
+            delete from todo_labels where todo_id=$1
+            "#,
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => RepositoryError::NotFound(id),
+            _ => RepositoryError::Unexpected(e.to_string()),
+        })?;
+        // todo delete
         sqlx::query(
             r#"
             delete from todos where id=$1
             "#,
         )
         .bind(id)
-        .execute(&self.pool) // 戻り値がないためexecute()
+        .execute(&self.pool)
         .await
         .map_err(|e| match e {
             sqlx::Error::RowNotFound => RepositoryError::NotFound(id),
             _ => RepositoryError::Unexpected(e.to_string()),
         })?;
+
+        tx.commit().await?;
 
         Ok(())
     }
@@ -259,16 +331,45 @@ mod test {
             .await
             .expect(&format!("fail connect database, url is [{}]", database_url));
 
+        // label data prepare
+        let label_name = String::from("test label");
+        let optional_label = sqlx::query_as::<_, Label>(
+            r#"
+            select * from labels where name = $1
+            "#,
+        )
+        .bind(label_name.clone())
+        .fetch_optional(&pool)
+        .await
+        .expect("Failed to prepare label data.");
+        let label_1 = if let Some(label) = optional_label {
+            label
+        } else {
+            let label = sqlx::query_as::<_, Label>(
+                r#"
+                insert into labels ( name )
+                values ( $1 )
+                returning *
+                "#,
+            )
+            .bind(label_name)
+            .fetch_one(&pool)
+            .await
+            .expect("Failed to insert label data.");
+            label
+        };
+
         let repository = TodoRepositoryForDb::new(pool.clone());
         let todo_text = "[crud_scenario] text";
 
         // create
         let created = repository
-            .create(CreateTodo::new(todo_text.to_string()))
+            .create(CreateTodo::new(todo_text.to_string(), vec![label_1.id]))
             .await
             .expect("[create] returned Err");
         assert_eq!(created.text, todo_text); // 用意したtextでTodoが作成されているか確認
         assert!(!created.completed); // completedがfalseでなければassert
+        assert_eq!(*created.labels.first().unwrap(), label_1);
 
         // find
         let todo = repository
@@ -290,12 +391,14 @@ mod test {
                 UpdateTodo {
                     text: Some(updated_text.to_string()),
                     completed: Some(true),
+                    labels: Some(vec![]),
                 },
             )
             .await
             .expect("[update] returned Err");
         assert_eq!(created.id, todo.id);
         assert_eq!(todo.text, updated_text);
+        assert!(todo.labels.len() == 0);
 
         // delete
         let _ = repository
@@ -315,6 +418,17 @@ mod test {
         .await
         .expect("[delete] todo_labels fetch error");
         assert!(todo_rows.len() == 0);
+
+        let rows = sqlx::query(
+            r#"
+            select * from todo_labels where todo_id=$1
+            "#,
+        )
+        .bind(todo.id)
+        .fetch_all(&pool)
+        .await
+        .expect("[delete] todo_labels fetch error");
+        assert!(rows.len() == 0);
     }
 }
 
@@ -341,8 +455,8 @@ pub mod test_utils {
     }
 
     impl CreateTodo {
-        pub fn new(text: String) -> Self {
-            Self { text }
+        pub fn new(text: String, labels: Vec<i32>) -> Self {
+            Self { text, labels }
         }
     }
 
@@ -431,9 +545,11 @@ pub mod test_utils {
             let expected = TodoEntity::new(id, text.clone());
 
             // create
+            todo!("labelデータの追加");
+            let labels = vec![];
             let repository = TodoRepositoryForMemory::new();
             let todo = repository
-                .create(CreateTodo { text })
+                .create(CreateTodo::new(text, labels))
                 .await
                 .expect("failed create todo");
             assert_eq!(expected, todo);
@@ -454,6 +570,7 @@ pub mod test_utils {
                     UpdateTodo {
                         text: Some(text.clone()),
                         completed: Some(true),
+                        labels: Some(vec![]),
                     },
                 )
                 .await


### PR DESCRIPTION
CRUD処理をラベルに対応

## TODO
- main.rsの擬似テスト(ForMemory)が未対応のため、DBと同等の動作を実装する